### PR TITLE
Remove restart setting from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
   postgres:
     image: postgres:10.4
-    restart: always
     ports: 
       - "5432:5432"
     container_name: "reperio-postgres"
@@ -12,7 +11,6 @@ services:
     build: ./docker-database/
   redis:
     image: redis:4.0.11
-    restart: always
     ports:
       - "6379:6379"
     container_name: "reperio-redis"


### PR DESCRIPTION
So the containers don't get automatically restarted even when they're not in use