### PR TITLE
REP-335 Update db config

### DIFF
--- a/config.js
+++ b/config.js
@@ -30,5 +30,12 @@ module.exports = {
         barUrl: process.env.CORE_BAR_URL || '',
         linkTimeout: process.env.CORE_LINK_TIMEOUT || 10
     },
-    redisOtpExpirationSeconds: process.env.REDIS_OTP_EXPIRATION_SECONDS || 60
+    redisOtpExpirationSeconds: process.env.REDIS_OTP_EXPIRATION_SECONDS || 60,
+    db: {
+        host: process.env.CORE_DB_HOST || 'localhost',
+        port: process.env.CORE_DB_PORT || '5432',
+        user: process.env.CORE_DB_USER || 'reperio',
+        password: process.env.CORE_DB_PASSWORD || 'reperio',
+        database: process.env.CORE_DB_DATABASE || 'reperio_platform_dev'
+    }
 };

--- a/db/connect.js
+++ b/db/connect.js
@@ -1,8 +1,7 @@
 const Knex = require('knex');
 const Model = require('objection').Model;
 
-const env = process.env.NODE_ENV || 'development';
-const knexConfig = require('./knexfile')[env];
+const knexConfig = require('./knexfile');
 
 const knex = Knex(knexConfig);
 

--- a/db/knexfile.js
+++ b/db/knexfile.js
@@ -1,75 +1,23 @@
- const config = {
-    development: {
-        client: 'pg',
-        connection: {
-            host: 'localhost',
-            port: '5432',
-            user: 'reperio',
-            password: 'reperio',
-            database: 'reperio_platform_dev',
-            dateStrings: true,
-            typeCast: (field, next) => {
-                //console.log('TypeCasting', field.type, field.length);
-                if (field.type === 'TINY' && field.length === 1) {
-                    let value = field.string();
-                    return value ? (value === '1') : null;
-                }
-                return next();
+ const config = require('../config');
+
+ module.exports = {
+    client: 'pg',
+    connection: {
+        ...config.db,
+        dateStrings: true,
+        typeCast: (field, next) => {
+            if (field.type === 'TINY' && field.length === 1) {
+                let value = field.string();
+                return value ? (value === '1') : null;
             }
-        },
-        migrations: {
-            tableName: 'knex_migrations',
-            directory: __dirname + '/migrations'
+            return next();
         }
     },
-    test: {
-        client: 'pg',
-        connection: {
-            host: process.env.PG_CONNECTION_HOST,
-            database: "reperio_platform",
-            user: process.env.PG_CONNECTION_USER,
-            timezone: 'UTC',
-            dateStrings: true,
-            typeCast: (field, next) => {
-                //console.log('TypeCasting', field.type, field.length);
-                if (field.type === 'TINY' && field.length === 1) {
-                    let value = field.string();
-                    return value ? (value === '1') : null;
-                }
-                return next();
-            }
-        },
-        migrations: {
-            tableName: 'knex_migrations',
-            directory: __dirname + '/migrations'
-        },
-        seeds: {
-            directory: __dirname + '/seeds'
-        }
+    migrations: {
+        tableName: 'knex_migrations',
+        directory: __dirname + '/migrations'
     },
-    production: {
-        client: 'mysql',
-        connection: {
-            host: 'localhost',
-            user: 'reperio',
-            password: 'mlQMLA6wbLMJwdCO',
-            database: 'reperio_platform_dev',
-            timezone: 'UTC',
-            dateStrings: true,
-            typeCast: (field, next) => {
-                //console.log('TypeCasting', field.type, field.length);
-                if (field.type === 'TINY' && field.length === 1) {
-                    let value = field.string();
-                    return value ? (value === '1') : null;
-                }
-                return next();
-            }
-        },
-        migrations: {
-            tableName: 'knex_migrations',
-            directory: __dirname + '/migrations'
-        }
+    seeds: {
+        directory: __dirname + '/seeds'
     }
 };
-
-module.exports = config;

--- a/db/migrations/20180101000000_createUuidExtension.js
+++ b/db/migrations/20180101000000_createUuidExtension.js
@@ -1,0 +1,8 @@
+
+exports.up = async function(knex) {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+};
+
+exports.down = async function(knex) {
+    await knex.raw('DROP EXTENSION IF EXISTS "uuid-ossp";');
+};

--- a/db/migrations/20180817112106_AddUniqueToEmail.js
+++ b/db/migrations/20180817112106_AddUniqueToEmail.js
@@ -9,6 +9,6 @@ exports.up = async function(knex, Promise) {
 exports.down = async function(knex, Promise) {
     await knex.schema
         .alterTable('users', t => {
-            t.dropUnique('primaryEmail');
+            t.string('primaryEmail').alter();
         });
 };

--- a/docker-database/create_fixtures.sql
+++ b/docker-database/create_fixtures.sql
@@ -1,3 +1,9 @@
 CREATE DATABASE reperio_platform_dev;
+CREATE DATABASE reperio_platform_test;
+
 CREATE USER reperio WITH PASSWORD 'reperio';
-GRANT ALL PRIVILEGES ON DATABASE "reperio_platform_dev" to reperio;
+ALTER USER reperio WITH SUPERUSER;
+
+GRANT ALL PRIVILEGES ON DATABASE reperio_platform_dev to reperio;
+GRANT ALL PRIVILEGES ON DATABASE reperio_platform_test to reperio;
+

--- a/docker-database/rebuild-db.sh
+++ b/docker-database/rebuild-db.sh
@@ -1,0 +1,15 @@
+# wipe and rebuild docker containers from scratch
+echo "rebuilding docker containers"
+docker-compose down 
+docker-compose build 
+docker-compose up -d
+
+# wait for postgres to start
+echo "\nwaiting for postgres"
+sleep 2 
+
+# run migrations and seed data on dev database
+echo "\nrunning migrations"
+knex migrate:latest --knexfile db/knexfile.js 
+echo "\nseeding data"
+knex seed:run --knexfile db/knexfile.js

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --coverage --verbose",
-    "start": "node index.js"
+    "start": "node index.js",
+    "rebuild-db": "./docker-database/rebuild-db.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Converts db config to be based on env variables, adds a script that will recreate the docker container from scratch (and then run migration and seed files), adds migration to create the 'uuid-ossp' extension, and fixes a down method in one of the migrations.