### PR TITLE
[ us-324 -> master ] Application Custom Verification Email Bodies

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -133,7 +133,7 @@ module.exports = [
                 await uow.commitTransaction();
 
                 //send verification email
-                await emailService.sendVerificationEmail(userEmail, uow, request);
+                await emailService.sendVerificationEmail(userEmail, uow, request, payload.applicationId);
 
                 return httpResponseService.loginSuccess(h, token);
             } catch (err) {
@@ -149,7 +149,8 @@ module.exports = [
                     lastName: Joi.string().required(),
                     primaryEmailAddress: Joi.string().required(),
                     password: Joi.string().required(),
-                    confirmPassword: Joi.string().required()
+                    confirmPassword: Joi.string().required(),
+                    applicationId: Joi.string().optional().allow(null).allow('')
                 }
             }
         }
@@ -170,7 +171,7 @@ module.exports = [
                     return httpResponseService.badData(h);
                 }
                 //send verification email
-                await emailService.sendVerificationEmail(userEmail, uow, request);
+                await emailService.sendVerificationEmail(userEmail, uow, request, payload.applicationId);
                 await uow.commitTransaction();
 
                 return true;
@@ -184,7 +185,8 @@ module.exports = [
             validate: {
                 payload: {
                     email: Joi.string().required(),
-                    userId: Joi.string().guid().required()
+                    userId: Joi.string().guid().required(),
+                    applicationId: Joi.string().optional().allow(null).allow('')
                 }
             }
         }

--- a/api/services/emailService.js
+++ b/api/services/emailService.js
@@ -5,8 +5,13 @@ class EmailService {
         const tokenUrl = `${request.server.app.config.webAppUrl}/emailVerification/${emailVerification.id}`;
         let emailContent = `Please <a href="${tokenUrl}">verify</a> your email address.`
 
-        switch (applicationId) {
-            case '2ce36838-27ae-4c00-b754-e2db7b61c577': // Reperio Managed IT Services
+        let application = uow.applicationsRepository.getApplicationById(applicationId);
+        if (!application) {
+            throw new Error("Application not found");
+        }
+
+        switch (application.name) {
+            case 'Managed IT Services': // Reperio Managed IT Services
                 emailContent = `Thanks for completing our survey, <a href="${tokenUrl}">click here</a> to go register your first desktop`
                 break;
         

--- a/api/services/emailService.js
+++ b/api/services/emailService.js
@@ -1,15 +1,25 @@
 class EmailService {
-    async sendVerificationEmail(userEmail, uow, request) {
+    async sendVerificationEmail(userEmail, uow, request, applicationId) {
         const messageHelper = await request.app.getNewMessageHelper();
         const emailVerification = await uow.emailVerificationsRepository.addEntry(userEmail.id, userEmail.userId);
-        const tokenUrl = `${request.server.app.config.webAppUrl}/emailVerification/${emailVerification.id}`
+        const tokenUrl = `${request.server.app.config.webAppUrl}/emailVerification/${emailVerification.id}`;
+        let emailContent = `Please <a href="${tokenUrl}">verify</a> your email address.`
+
+        switch (applicationId) {
+            case '2ce36838-27ae-4c00-b754-e2db7b61c577': // Reperio Managed IT Services
+                emailContent = `Thanks for completing our survey, <a href="${tokenUrl}">click here</a> to go register your first desktop`
+                break;
+        
+            default:
+                break;
+        }
 
         const message = {
             to: userEmail.email,
             from: request.server.app.config.email.sender,
             type: 'email',
             subject: 'Email verification',
-            contents: `Please <a href="${tokenUrl}">verify</a> your email address.`
+            contents: emailContent
         };
 
         return await messageHelper.processMessage(message);

--- a/api/users.js
+++ b/api/users.js
@@ -102,7 +102,8 @@ module.exports = [
                     organizationIds: Joi.array()
                     .items(
                         Joi.string().guid()
-                    ).optional()
+                    ).optional(),
+                    applicationId: Joi.string().optional().allow(null).allow('')
                 }
             }
         },
@@ -143,7 +144,7 @@ module.exports = [
             await uow.commitTransaction();
 
             //send verification email
-            await emailService.sendVerificationEmail(userEmail, uow, request);
+            await emailService.sendVerificationEmail(userEmail, uow, request, payload.applicationId);
 
             return updatedUser;
         }
@@ -203,7 +204,8 @@ module.exports = [
                             email: Joi.string().email(),
                             id: Joi.string().guid().allow(null)
                         })
-                    )
+                    ),
+                    applicationId: Joi.string().optional().allow(null).allow('')
                 }
             }
         },
@@ -221,7 +223,7 @@ module.exports = [
 
             if (newOrReusedUserEmails) {
                 const promises = newOrReusedUserEmails.map(async userEmail => {
-                    return await emailService.sendVerificationEmail(userEmail, uow, request)
+                    return await emailService.sendVerificationEmail(userEmail, uow, request, payload.applicationId)
                 });
 
                 Promise.all(promises);

--- a/db/seeds/9-managedItApplication.js
+++ b/db/seeds/9-managedItApplication.js
@@ -1,0 +1,24 @@
+exports.seed = async function(knex, Promise) {
+    // Deletes ALL existing entries
+    await knex('applicationOrganizations').del();
+    await knex('applications').del();
+
+    // Inserts seed entries
+    await knex('applications').insert([
+        {
+            id: '2ce36838-27ae-4c00-b754-e2db7b61c577',
+            name: 'Managed IT Services',
+            apiUrl: 'http://localhost:3002/api/v1',
+            clientUrl: 'http://localhost:8082',
+            secretKey: 'f3356c2d6619aaf57be43f69baccd3e871f37dad9e57d6b705c50501085e0cb3f961ec43f67da13a9a186c378ac55710'
+        }
+    ]);
+
+    await knex('applicationOrganizations').insert([
+        {
+            applicationId: '2ce36838-27ae-4c00-b754-e2db7b61c577',
+            organizationId: '966f4157-934c-45e7-9f44-b1e5fd8b79a7',
+            active: true
+        }
+    ]);
+}


### PR DESCRIPTION
[Link to Target Process](https://sevenhillstechnology.tpondemand.com/entity/329-api-add-email-template-based-on)

Added an option to pass `applicationId` to the `sendVerificationEmail` of the email service. If the application id is present and used in the switch, it will use the custom email body, instead of the default. Also added option to send `applicationId` along in the payload of all platform api routes that call the email service.