### PR TITLE
us-2639 - update reperio-platform-api_postgres to use port 54322 on the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: "reperio-core-postgres"
     build: ./docker/db
     ports:
-      - "5432"
+      - "54322:5432"
     volumes:
       - data-volume:/usr/local/pgsql/data
     networks:


### PR DESCRIPTION
…host

https://sevenhillstechnology.tpondemand.com/RestUI/Board.aspx#page=board/5165084486614971430&appConfig=eyJhY2lkIjoiODU0Q0U1NzU0OUI1OTcxNzI4RTcyRTE0NzM0MTdDNUYiLCJhcHBDb250ZXh0Ijp7InByb2plY3RDb250ZXh0Ijp7Im5vIjpmYWxzZX0sInRlYW1Db250ZXh0Ijp7Im5vIjp0cnVlfX19&boardPopup=userstory/2639/silent