### PR TITLE
[ us-2769 -> dev ] Adding reperio-network to docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ before_script:
     - sudo service redis-server stop
     # wait for redis to shutdown
     - while sudo lsof -Pi :6379 -sTCP:LISTEN -t; do sleep 1; done
+    - docker network create reperio-network
     - yarn run rebuild-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - /opt/app/node_modules
     networks:
       - local
+      - reperio
     command: ["docker/app/start.sh"]
 
 volumes:
@@ -39,3 +40,6 @@ volumes:
 
 networks:
   local:
+  reperio:
+    external:
+      name: reperio-network


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/2769-add-external-docker-network)

Add to up script to create network (before `docker-compose` statements)
```
docker network create reperio-network &
```

Add to down script to remove network (after `docker-compose` statements)
```
docker network rm reperio-network
```

Related PR: https://github.com/reperio/managed-it-api/pull/24