### PR TITLE
[ id:2791 -> dev ] Opening debugging port and adding --inspect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       dockerfile: ./docker/app/Dockerfile
     ports:
       - "3000:3000"
+      - "9229:9229"
     volumes:
       - .:/opt/app
       - /opt/app/node_modules

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -4,4 +4,4 @@ set -e
 
 yarn
 (cd db && node initializeDatabase.js)
-nodemon index.js
+nodemon --inspect=0.0.0.0 index.js


### PR DESCRIPTION
Updates to `docker-compose` and `start.sh` to allow for remote debugging.

Example of vscode launch setting to attach debugger
```
{
    "type": "node",
    "request": "attach",
    "name": "Docker: reperio-platform-api (Attach to Node)",
    "remoteRoot": "/opt/app",
    "port": 9229,
    "address": "127.0.0.1",
    "localRoot": "${workspaceFolder}/reperio-platform-api",
    "protocol": "inspector",
    "restart": true
}
```

Related PR: https://github.com/reperio/managed-it-api/pull/27