### PR TITLE
[ us-2817 -> dev ] Updating GET /organizations routes

### DIFF
--- a/api/organization.js
+++ b/api/organization.js
@@ -123,28 +123,6 @@ module.exports = [
     },
     {
         method: 'GET',
-        path: '/organizations/user/{userId}',
-        handler: async (request, h) => {
-            const uow = await request.app.getNewUoW();
-            const logger = request.server.app.logger;
-            const userId = request.params.userId;
-
-            logger.debug(`Fetching all organizations by user: ${userId}`);
-
-            const organizations = await uow.organizationsRepository.getOrganizationsByUser(userId);
-            
-            return organizations;
-        },
-        options: {
-            validate: {
-                params: {
-                    userId: Joi.string().guid().required()
-                }
-            }
-        }
-    },
-    {
-        method: 'GET',
         path: '/organizations/{organizationId}',
         config: {
             plugins: {

--- a/api/users.js
+++ b/api/users.js
@@ -306,6 +306,28 @@ module.exports = [
         }
     },
     {
+        method: 'GET',
+        path: '/users/{userId}/organizations',
+        handler: async (request, h) => {
+            const uow = await request.app.getNewUoW();
+            const logger = request.server.app.logger;
+            const userId = request.params.userId;
+
+            logger.debug(`Fetching all organizations by user: ${userId}`);
+
+            const organizations = await uow.organizationsRepository.getOrganizationsByUser(userId);
+            
+            return organizations;
+        },
+        options: {
+            validate: {
+                params: {
+                    userId: Joi.string().guid().required()
+                }
+            }
+        }
+    },
+    {
         method: 'PUT',
         path: '/users/{userId}/organizations',
         config: {


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/2817)

Making GET /organizations look for only organizations by userId, or if admin permission exists, get all organizations.

Moving GET /organizations/user/{userId} to users.js and changing route to /users/{userId}/organizations to follow consistent REST route semantics 