### PR TITLE
[ us-2843 -> dev ] Updates to make emails work locally and go to auth-ui

### DIFF
--- a/api/services/emailService.js
+++ b/api/services/emailService.js
@@ -33,7 +33,7 @@ class EmailService {
     async sendForgotPasswordEmail(userEmail, uow, request) {
         const messageHelper = await request.app.getNewMessageHelper();
         const forgotPassword = await uow.forgotPasswordsRepository.addEntry(userEmail.id, userEmail.userId);
-        const tokenUrl = `${request.server.app.config.webAppUrl}/resetPassword/${forgotPassword.id}`
+        const tokenUrl = `${request.server.app.config.authWebAppUrl}/resetPassword/${forgotPassword.id}`
 
         const message = {
             to: userEmail.email,

--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ module.exports = {
     secret: process.env.CORE_SECRET || '6LfjumIUAAAAAI33bLW6by3Ny3QOE50YxvW_05q3',
     localTimezone: process.env.CORE_TIMEZONE || 'America/New_York',
     webAppUrl: process.env.CORE_APP_URL || 'http://localhost:8080',
+    authWebAppUrl: process.env.AUTH_APP_URL || 'http://localhost:8081',
     limitEnabled: process.env.LIMIT_ENABLED || true,
     //number of total requests that can be made on a given path per period. Set to false to disable limiting requests per path.
     limitPath: process.env.LIMIT_PATH || 50,
@@ -19,7 +20,7 @@ module.exports = {
         expiresIn: process.env.LIMIT_USER_PATH_CACHE_EXPIRES || 60000
     },
     email: {
-        smtpHost: process.env.CORE_SMTP_HOST || 'localhost',
+        smtpHost: process.env.CORE_SMTP_HOST || 'reperio-core-mail',
         smtpPort: process.env.CORE_SMTP_PORT || 25,
         smtpUser: process.env.CORE_SMTP_USER || '',
         smtpPassword: process.env.CORE_SMTP_USER_PASSWORD || '',
@@ -27,7 +28,7 @@ module.exports = {
         sendGridApiKey: process.env.CORE_SENDGRID_API_KEY || '',
         method: process.env.CORE_EMAIL_METHOD || 'smtp', // must be either 'smtp' or 'sendgrid',
         rejectUnauthorizedTLS: process.env.CORE_SMTP_REJECT_UNAUTHORIZED_TLS || false,
-        barUrl: process.env.CORE_BAR_URL || '',
+        barUrl: process.env.CORE_BAR_URL || 'https://sms-gateway-test.reper.io/reperio-bar.png',
         linkTimeout: process.env.CORE_LINK_TIMEOUT || 10
     },
     redisOtpExpirationSeconds: process.env.REDIS_OTP_EXPIRATION_SECONDS || 60,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,14 @@ services:
       - local
       - reperio
     command: ["docker/app/start.sh"]
-
+  maildev:
+    container_name: "reperio-core-mail"
+    image: "djfarrelly/maildev"
+    ports:
+      - "1080:80"
+    networks:
+      - local
+      - reperio
 volumes:
     data-volume:
     redis-data:


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/2843-add-password-reset-workflow-into-auth)

Adding docker-compose to use [MailDev](https://danfarrelly.nyc/MailDev/) for local mail testing through docker (on port 1025)

Related PR: https://github.com/reperio/reperio-auth-ui/pull/2