### PR TITLE
[ bug-3161 -> dev ] Organization with Address creation respects Personal value

### DIFF
--- a/api/organization.js
+++ b/api/organization.js
@@ -44,7 +44,7 @@ module.exports = [
 
                 if (existingOrganization == null) {
                     logger.debug(`Creating the organization ${organizationModel.name}`);
-                    organization = await uow.organizationsRepository.createOrganizationWithAddress(organizationModel);
+                    organization = await uow.organizationsRepository.createOrganizationWithAddress(organizationModel, payload.personal);
                 }
                 else{
                     return httpResponseService.conflict(h);


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/3161-loading-organizations-to-select-for-survey)

From a survey, we were posting new orgs for existing users as non-personal, but the value wasn't being passed to the repo, which defaulted it to `true`

Related PR: https://github.com/reperio/managed-it-ui/pull/38