### PR TITLE
[ bug-3485 -> dev ] Fixing variable declaration in switch, adding trycatch to email verification

### DIFF
--- a/api/applications.js
+++ b/api/applications.js
@@ -179,7 +179,12 @@ module.exports = [
                     if (payload.sendConfirmationEmail) {
                         logger.debug(`Sending user verification email to user: ${user.id}`);
 
-                        await emailService.sendVerificationEmail(userEmail, uow, request, request.params.applicationId);
+                        try {
+                            await emailService.sendVerificationEmail(userEmail, uow, request, request.params.applicationId);
+                        } catch (error) {
+                            logger.error(`Failed to send verification email to user ${user.id}`);
+                            logger.error(error);
+                        }
                     }
 
                     let response = {

--- a/api/services/emailService.js
+++ b/api/services/emailService.js
@@ -3,6 +3,7 @@ class EmailService {
         const messageHelper = await request.app.getNewMessageHelper();
         const forgotPassword = await uow.forgotPasswordsRepository.addEntry(userEmail.id, userEmail.userId);
         let tokenUrl = `${request.server.app.config.authWebAppUrl}/passwordManagement/${forgotPassword.id}/create`;
+        let encodedNext = encodeURIComponent(request.server.app.config.webAppUrl);
         let emailContent;
 
         let application = await uow.applicationsRepository.getApplicationById(applicationId);
@@ -12,13 +13,12 @@ class EmailService {
 
         switch (application.name) {
             case 'Managed IT Services': // Reperio Managed IT Services
-                const encodedNext = encodeURIComponent(application.clientUrl + '/login');
+                encodedNext = encodeURIComponent(application.clientUrl + '/login');
                 tokenUrl = `${tokenUrl}?next=${encodedNext}`; 
-                emailContent = `Thanks for completing our survey, <a href="${tokenUrl}">click here</a> to go register your first desktop`
+                emailContent = `Thanks for completing our survey, <a href="${tokenUrl}">click here</a> to set your password and go register your first desktop!`
                 break;
         
             default:
-                const encodedNext = encodeURIComponent(request.server.app.config.webAppUrl);
                 tokenUrl = `${tokenUrl}?next=${encodedNext}`; 
                 emailContent = `Please <a href="${tokenUrl}">verify</a> your email address.`;
                 break;


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/3485-unauthenticated-survey-submission-fails-on-verification)

Issue was from `encodedNext` being declared twice. Updated to fix that, add a try catch for logging, and wording change to email verification message content