### PR TITLE
id:4086 adding route to get all users for organization

### DIFF
--- a/api/organization.js
+++ b/api/organization.js
@@ -288,5 +288,35 @@ module.exports = [
                 throw err;
             }
         }
+    },
+    {
+        method: 'GET',
+        path: '/organizations/{organizationId}/users',
+        config: {
+            auth: {
+                strategies: ['jwt', 'application-token']
+            },
+            validate: {
+                params: {
+                    organizationId: Joi.string().guid().required()
+                }
+            }
+        },
+        handler: async (request, h) => {
+            const uow = await request.app.getNewUoW();
+            const logger = request.server.app.logger;
+            const {organizationId} = request.params;
+            
+            logger.debug(`Fetching all users for organization id: ${organizationId}`);
+
+            try {
+                const users =  await uow.usersRepository.getUsersByOrganizationId(organizationId);
+                return users;
+            } catch (err) {
+                logger.error(`Failed to fetch all users for organization id: ${organizationId}`);
+                logger.error(err);
+                throw err;
+            }
+        }
     }
 ];

--- a/db/repositories/usersRepository.js
+++ b/db/repositories/usersRepository.js
@@ -132,6 +132,21 @@ class UsersRepository {
         }
     }
 
+    async getUsersByOrganizationId(organizationId) {
+        try {
+            return await this.uow._models.User
+                .query(this.uow._transaction)
+                .select(['users.*', 'roles.name AS role'])
+                .join('userRoles', 'users.id', 'userRoles.userId')
+                .join('roles', 'roles.id', 'userRoles.roleId')
+                .where('roles.organizationId', organizationId);
+        } catch (err) {
+            this.uow._logger.error(`Failed to fetch user using id: ${userId}`);
+            this.uow._logger.error(err);
+            throw err;
+        }
+    }
+
     async getAllUsers() {
         try {
             return await this.uow._models.User


### PR DESCRIPTION
**DRAFT** because I may need to adjust the output of the route. I mainly want the [core connector PR](https://github.com/reperio/core-connector/pull/30) in so I can test locally without yarn linking.